### PR TITLE
feat: Add toggle_orientation to flip a container between rows and columns

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -111,6 +111,10 @@ default_keys = false
 "Alt + Backslash" = { split = "horizontal" }
 "Alt + Equal" = { split = "vertical" }
 
+# Flip the parent container between horizontal and vertical, rearranging the
+# windows already inside it. A group stays a group: tabbed becomes stacked.
+"Alt + Slash" = "toggle_orientation"
+
 # Change the parent node to a horizontal or vertical group, also known as
 # "tabbed" and "stacked" respectively. Groups show one window at a time,
 # allocating their entire frame to that window.

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -36,6 +36,7 @@ pub enum LayoutCommand {
     Descend,
     MoveNode(Direction),
     Split(Orientation),
+    ToggleOrientation,
     Group(Orientation),
     Ungroup,
     ToggleFocusFloating,
@@ -145,6 +146,7 @@ impl LayoutCommand {
         use LayoutCommand::*;
         match self {
             MoveNode(_)
+            | ToggleOrientation
             | Group(_)
             | Ungroup
             | Resize { .. }
@@ -994,6 +996,13 @@ impl LayoutManager {
                 // usually have a visible effect.
                 let selection = self.tree.selection(layout);
                 self.tree.nest_in_container(layout, selection, ContainerKind::from(orientation));
+                EventResponse::default()
+            }
+            LayoutCommand::ToggleOrientation => {
+                if let Some(parent) = self.tree.selection(layout).parent(self.tree.map()) {
+                    let kind = self.tree.container_kind(parent);
+                    self.tree.set_container_kind(parent, kind.flip());
+                }
                 EventResponse::default()
             }
             LayoutCommand::Group(orientation) => {
@@ -2841,6 +2850,71 @@ mod tests {
             ],
             mgr.layout_sorted(space, screen),
         );
+    }
+
+    #[test]
+    fn it_flips_the_container_with_toggle_orientation() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 100, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        // Side by side becomes stacked top to bottom.
+        _ = mgr.handle_command(Some(space), &[space], ToggleOrientation);
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 100, 50)),
+                (WindowId::new(pid, 2), rect(0, 50, 100, 50)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        // Toggling again returns to the original layout.
+        _ = mgr.handle_command(Some(space), &[space], ToggleOrientation);
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn toggle_orientation_keeps_a_group_a_group() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 100, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        _ = mgr.handle_command(Some(space), &[space], Group(Orientation::Horizontal));
+        _ = mgr.handle_command(Some(space), &[space], ToggleOrientation);
+
+        let layout = mgr.layout(space);
+        let parent = mgr.tree.selection(layout).parent(mgr.tree.map()).unwrap();
+        assert_eq!(ContainerKind::Stacked, mgr.tree.container_kind(parent));
     }
 
     #[test]

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -69,6 +69,18 @@ impl ContainerKind {
             _ => false,
         }
     }
+
+    /// Returns the kind with the opposite orientation, staying within the
+    /// group or non-group pair so a tabbed container does not become a split.
+    pub fn flip(self) -> Self {
+        use ContainerKind::*;
+        match self {
+            Horizontal => Vertical,
+            Vertical => Horizontal,
+            Tabbed => Stacked,
+            Stacked => Tabbed,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## What

Adds a `toggle_orientation` command that flips the parent container of the selected node between horizontal and vertical, rearranging the windows already inside it.

```toml
"Alt + Slash" = "toggle_orientation"
```

## Why

`split` declares an orientation for windows opened *later*. Once a container already holds windows, there is no way to change how they are arranged short of moving each one out and back.

## How

Adds `ContainerKind::flip()` in `model/size.rs` and a handler that looks up the selected node's parent and sets the flipped kind — the same parent-lookup pattern the neighbouring `Group` and `Ungroup` handlers already use.

Groups stay groups: `Tabbed` flips to `Stacked` and back, so the command never silently converts a group into a split.

## Tests

Two, both verified to fail before the change and pass after:

- `it_flips_the_container_with_toggle_orientation` — side-by-side becomes stacked, and toggling again restores the original frames
- `toggle_orientation_keeps_a_group_a_group` — a tabbed container becomes stacked rather than vertical

## Notes

Purely additive; no existing behaviour changes. `Alt + Slash` was unbound in `glide.default.toml`.

Happy to move this to an issue first if you would rather discuss the command name or the default binding.