### PR TITLE
feat: Add balance command to even out window sizes

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -121,6 +121,10 @@ default_keys = false
 "Alt + S" = { group = "vertical" }
 "Alt + E" = "ungroup"
 
+# Reset every container on the space to divide its space evenly, undoing any
+# resizing.
+"Alt + Shift + Digit0" = "balance"
+
 # Float the current node. Floating windows are allowed to overlap and keep
 # whatever size and position you give them. Note that they do not actually
 # float on top of other windows, as that would require disabling security

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -38,6 +38,7 @@ pub enum LayoutCommand {
     Split(Orientation),
     Group(Orientation),
     Ungroup,
+    Balance,
     ToggleFocusFloating,
     ToggleWindowFloating,
     ToggleFullscreen,
@@ -147,6 +148,7 @@ impl LayoutCommand {
             MoveNode(_)
             | Group(_)
             | Ungroup
+            | Balance
             | Resize { .. }
             | CycleColumnWidth
             | ToggleColumnTabbed => true,
@@ -1011,6 +1013,11 @@ impl LayoutManager {
                         )
                     }
                 }
+                EventResponse::default()
+            }
+            LayoutCommand::Balance => {
+                let root = self.tree.root(layout);
+                self.tree.balance(root);
                 EventResponse::default()
             }
             LayoutCommand::ToggleFullscreen => {
@@ -2834,6 +2841,46 @@ mod tests {
                 percent: 10.0,
             },
         );
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn it_evens_out_window_sizes_with_balance() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 100, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        _ = mgr.handle_command(
+            Some(space),
+            &[space],
+            Resize {
+                direction: Direction::Right,
+                percent: 20.0,
+            },
+        );
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 70, 100)),
+                (WindowId::new(pid, 2), rect(70, 0, 30, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        _ = mgr.handle_command(Some(space), &[space], Balance);
         assert_eq!(
             vec![
                 (WindowId::new(pid, 1), rect(0, 0, 50, 100)),

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -688,6 +688,18 @@ impl LayoutTree {
         self.tree.data.size.last_ungrouped_kind(node)
     }
 
+    /// Gives every node under `node` the same size as its siblings, so each
+    /// container divides its space evenly.
+    pub fn balance(&mut self, node: NodeId) {
+        let mut stack = vec![node];
+        while let Some(node) = stack.pop() {
+            for child in node.children(&self.tree.map) {
+                self.tree.data.size.set_weight(child, 1.0, &self.tree.map);
+                stack.push(child);
+            }
+        }
+    }
+
     pub fn set_container_kind(&mut self, node: NodeId, kind: ContainerKind) {
         self.tree.data.size.set_kind(node, kind);
     }
@@ -1519,6 +1531,47 @@ mod tests {
         let a3 = tree.add_window_under(layout, old_root, WindowId::new(1, 3));
         tree.assert_children_are([a1, a2, a3], old_root);
         assert_eq!(b2, tree.selection(layout));
+    }
+
+    #[test]
+    fn balance() {
+        // ┌─────┬─────┐
+        // │     │ b1  │
+        // │ a1  +─────+
+        // │     │ b2  │
+        // └─────┴─────┘
+        let mut tree = LayoutTree::new();
+        let layout = tree.create_layout();
+        let root = tree.root(layout);
+        let a1 = tree.add_window_under(layout, root, WindowId::new(1, 1));
+        let a2 = tree.add_container(root, ContainerKind::Vertical);
+        let b1 = tree.add_window_under(layout, a2, WindowId::new(2, 1));
+        let _b2 = tree.add_window_under(layout, a2, WindowId::new(2, 2));
+        let screen = rect(0, 0, 1000, 1000);
+        let config = &Config::default();
+
+        // Skew both levels of the tree.
+        tree.resize(a1, 0.2, Direction::Right);
+        tree.resize(b1, 0.2, Direction::Down);
+        assert_frames_are(
+            tree.calculate_layout(layout, screen, config),
+            [
+                (WindowId::new(1, 1), rect(0, 0, 700, 1000)),
+                (WindowId::new(2, 1), rect(700, 0, 300, 700)),
+                (WindowId::new(2, 2), rect(700, 700, 300, 300)),
+            ],
+        );
+
+        // Balancing the root evens out the nested container too.
+        tree.balance(root);
+        assert_frames_are(
+            tree.calculate_layout(layout, screen, config),
+            [
+                (WindowId::new(1, 1), rect(0, 0, 500, 1000)),
+                (WindowId::new(2, 1), rect(500, 0, 500, 500)),
+                (WindowId::new(2, 2), rect(500, 500, 500, 500)),
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a `balance` command that resets every container on the space so it divides its space evenly among its children, undoing any resizing.

```toml
"Alt + Shift + Digit0" = "balance"
```

## Why

After resizing a few windows there is no way back to an even layout short of closing and reopening them. i3, sway and AeroSpace all have an equivalent.

## How

Sizing is stored as a weight per node, so balancing is a matter of setting every weight to 1. `LayoutTree::balance()` walks the subtree iteratively and does that.

The walk covers nested containers, not just the one holding the focused window, so a single press evens out the whole space.

## Tests

Two, both verified to fail before the change and pass after:

- `it_evens_out_window_sizes_with_balance` (actor) — resize to 70/30, then balance back to 50/50
- `balance` (model) — skews two levels of the tree and asserts the nested container is evened too, not just the root

## Notes

Purely additive; no existing behaviour changes.

I noticed #156 ("Rebuild/Rebalance layout tree") while looking for prior art. That one reads as repairing a corrupted tree rather than equal-sizing, so I have kept this separate — happy to be corrected if you intended them as the same thing.