### PR TITLE
feat: Let resize pick the axis when no direction is given

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -92,6 +92,15 @@ default_keys = false
 "Alt + Ctrl + K" = { resize = { direction = "up", percent = 5 } }
 "Alt + Ctrl + L" = { resize = { direction = "right", percent = 5 } }
 
+# Omit the direction to grow or shrink along whichever axis the container
+# lays its children out on, so one key pair works in both a row and a
+# column. A negative percent shrinks.
+#
+# The space comes from the next window, or the previous one when there is
+# no next. A window in the middle of a row always moves its right edge.
+"Alt + Minus" = { resize = { percent = -5 } }
+"Alt + Shift + Equal" = { resize = { percent = 5 } }
+
 # Move up or down the tree hierarchy, selecting a parent or child node
 # respectively. These commands change which node is selected (similar to
 # move_focus) rather than moving windows. The selected node affects subsequent

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -42,8 +42,10 @@ pub enum LayoutCommand {
     ToggleWindowFloating,
     ToggleFullscreen,
     Resize {
-        #[serde(rename = "direction")]
-        direction: Direction,
+        /// The edge to move. Omit to resize along whichever axis the
+        /// container lays its children out on.
+        #[serde(rename = "direction", default)]
+        direction: Option<Direction>,
         #[serde(default = "default_resize_percent")]
         percent: f64,
     },
@@ -1036,7 +1038,10 @@ impl LayoutManager {
             LayoutCommand::Resize { direction, percent } => {
                 let percent = percent.clamp(-100.0, 100.0);
                 let node = self.tree.selection(layout);
-                self.tree.resize(node, percent / 100.0, direction);
+                match direction {
+                    Some(direction) => self.tree.resize(node, percent / 100.0, direction),
+                    None => self.tree.resize_smart(node, percent / 100.0),
+                };
                 EventResponse::default()
             }
             LayoutCommand::CycleColumnWidth => {
@@ -2788,6 +2793,122 @@ mod tests {
     }
 
     #[test]
+    fn resize_without_a_direction_grows_and_shrinks_either_window() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 100, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        let grow = Resize { direction: None, percent: 10.0 };
+        let shrink = Resize {
+            direction: None,
+            percent: -10.0,
+        };
+
+        _ = mgr.handle_command(Some(space), &[space], grow.clone());
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 60, 100)),
+                (WindowId::new(pid, 2), rect(60, 0, 40, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        _ = mgr.handle_command(Some(space), &[space], shrink.clone());
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        // The last window has no neighbour on its far side. Growing it has to
+        // take from the window before it rather than doing nothing.
+        _ = mgr.handle_command(Some(space), &[space], MoveFocus(Direction::Right));
+        _ = mgr.handle_command(Some(space), &[space], grow);
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 40, 100)),
+                (WindowId::new(pid, 2), rect(40, 0, 60, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+
+        _ = mgr.handle_command(Some(space), &[space], shrink);
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn resize_without_a_direction_takes_from_the_next_window() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 3);
+
+        let screen = rect(0, 0, 900, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 2)));
+
+        // The middle window has a neighbour on both sides. It takes from the
+        // one after it, leaving the window before it where it is.
+        _ = mgr.handle_command(Some(space), &[space], Resize { direction: None, percent: 10.0 });
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 300, 100)),
+                (WindowId::new(pid, 2), rect(300, 0, 390, 100)),
+                (WindowId::new(pid, 3), rect(690, 0, 210, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn resize_without_a_direction_follows_the_container_axis() {
+        use LayoutCommand::*;
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 1);
+
+        let screen = rect(0, 0, 100, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        // Stack the windows vertically, so growing means taller, not wider.
+        _ = mgr.handle_command(Some(space), &[space], Split(Orientation::Vertical));
+        _ = mgr.handle_event(WindowAdded(space, WindowId::new(pid, 2), win_info()));
+        _ = mgr.handle_event(WindowFocused(vec![space], WindowId::new(pid, 1)));
+
+        _ = mgr.handle_command(Some(space), &[space], Resize { direction: None, percent: 10.0 });
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 100, 60)),
+                (WindowId::new(pid, 2), rect(0, 60, 100, 40)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
     fn it_resizes_windows_with_resize_command() {
         use LayoutCommand::*;
         use LayoutEvent::*;
@@ -2813,7 +2934,7 @@ mod tests {
             Some(space),
             &[space],
             Resize {
-                direction: Direction::Right,
+                direction: Some(Direction::Right),
                 percent: 10.0,
             },
         );
@@ -2830,7 +2951,7 @@ mod tests {
             Some(space),
             &[space],
             Resize {
-                direction: Direction::Left,
+                direction: Some(Direction::Left),
                 percent: 10.0,
             },
         );

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::selection::Selection;
-use super::size::{ContainerKind, Direction, Size};
+use super::size::{ContainerKind, Direction, Orientation, Size};
 use super::tree::{self, Tree};
 use super::window::Window;
 use crate::actor::app::{WindowId, pid_t};
@@ -800,6 +800,41 @@ impl LayoutTree {
         }
         self.apply_resize(resizing_node, sibling, parent, delta / px_per_weight);
         true
+    }
+
+    /// Grows or shrinks `node` along whichever axis its container lays its
+    /// children out on, so one key works for both a row and a column.
+    ///
+    /// A positive ratio always grows and a negative one always shrinks, no
+    /// matter which side the neighbour is on.
+    ///
+    /// The space always comes from the neighbour after `node`, falling back
+    /// to the one before it when `node` is last. A node in the middle of a
+    /// row therefore always moves its right edge, rather than picking the
+    /// side with more room: which neighbour is larger changes as the layout
+    /// changes, so choosing by size would move a different edge on each
+    /// press.
+    pub fn resize_smart(&mut self, node: NodeId, screen_ratio: f64) -> bool {
+        let Some(parent) = node.parent(&self.tree.map) else {
+            return false;
+        };
+        let kind = self.tree.data.size.kind(parent);
+        if kind.is_group() {
+            return false;
+        }
+        let (forward, back) = match kind.orientation() {
+            Orientation::Horizontal => (Direction::Right, Direction::Left),
+            Orientation::Vertical => (Direction::Down, Direction::Up),
+        };
+        // Prefer the neighbour past the node's far edge, but fall back to the
+        // near one so a node at the edge of its container can still resize.
+        // A positive ratio grows the node whichever edge is moving, so the
+        // sign carries over to the fallback unchanged.
+        if self.resize_target(node, forward).is_some() {
+            self.resize(node, screen_ratio, forward)
+        } else {
+            self.resize(node, screen_ratio, back)
+        }
     }
 
     pub fn resize(&mut self, node: NodeId, screen_ratio: f64, direction: Direction) -> bool {


### PR DESCRIPTION
## The bug

A window at the *end* of its container has no neighbour past its far edge, so there is nobody to take space from and `resize` silently does nothing.

With three windows in a row and the last one focused, `Alt + Ctrl + L` does nothing today. The key looks broken rather than inapplicable, and which key is dead depends on where the focused window happens to sit.

## What this changes

`direction` becomes optional on `resize`. Omitting it resizes along whichever axis the container lays its children out on, and falls back to the near-side neighbour when there is no far-side one:

```toml
"Alt + Minus" = { resize = { percent = -5 } }
"Alt + Shift + Equal" = { resize = { percent = 5 } }
```

One key pair then grows and shrinks in both a row and a column, and works on every window including the last. A negative percent shrinks.

## Which neighbour it takes from

The space always comes from the **next** window, falling back to the **previous** one when there is no next. So a window in the middle of a row always moves its right edge:

```
before   [300][300][300]
grow     [300][390][210]     right edge moved; left window untouched
```

I considered taking from whichever neighbour has more room. I did not do that because which neighbour is larger changes as the layout changes, so repeated presses would move a different edge each time. A fixed rule is duller but stays predictable, which seemed like the better trade for a key you hold down. Happy to change it if you would rather it chose by size.

Within a nested tree it operates on the container the window actually belongs to. A window in a vertical stack inside a horizontal split grows downward, trading with its stack-mate rather than with the window beside the stack.

Groups return early: only one window is visible at a time, so there is nothing to trade.

## Compatibility

`#[serde(default)]` on the field means every existing config parses unchanged, and `resize` with an explicit direction behaves exactly as before — including the dead-key case above, which I left alone rather than changing shipped behaviour. If you would prefer the fallback applied to explicit directions too, that is a one-line change.

## Tests

Three, each verified to fail before the change and pass after:

- `resize_without_a_direction_grows_and_shrinks_either_window` — grow/shrink from both the first and the last window, covering the fallback
- `resize_without_a_direction_takes_from_the_next_window` — pins the middle-window rule above
- `resize_without_a_direction_follows_the_container_axis` — a vertical container resizes height, not width