### PR TITLE
feat: Add default_root_orientation to split a portrait screen vertically

### DIFF
--- a/glide.default.toml
+++ b/glide.default.toml
@@ -30,6 +30,17 @@ inner_gap = 0
 # Note: "scroll" requires settings.experimental.scroll.enable = true.
 default_layout_kind = "tree"
 
+# Which way a new layout's root container splits: "horizontal", "vertical",
+# or "auto".
+#
+# "auto" splits the screen's longer axis, so windows stack on a portrait
+# screen and sit side by side on a landscape one. Without it two windows on
+# a portrait screen become tall narrow strips.
+#
+# This applies when a layout is first created. A layout that moves to a
+# differently shaped screen keeps the orientation it already has.
+default_root_orientation = "horizontal"
+
 # Visual bars for window groups (tabbed/stacked containers).
 group_bars.enable = true
 group_bars.thickness = 6

--- a/src/actor/layout.rs
+++ b/src/actor/layout.rs
@@ -531,11 +531,11 @@ impl LayoutManager {
             LayoutEvent::SpaceExposed(space, size) => {
                 self.debug_tree(space);
                 let kind = self.default_layout_kind;
+                let orientation = self.config.settings.default_root_orientation.resolve(size);
                 {
-                    let mapping = self
-                        .layout_mapping
-                        .entry(space)
-                        .or_insert_with(|| SpaceLayoutMapping::new(size, &mut self.tree, kind));
+                    let mapping = self.layout_mapping.entry(space).or_insert_with(|| {
+                        SpaceLayoutMapping::new(size, &mut self.tree, kind, orientation)
+                    });
                     mapping.activate_size(size, &mut self.tree);
                 }
                 self.ensure_layout_kind_allowed_for_space(space);
@@ -2838,6 +2838,81 @@ mod tests {
             vec![
                 (WindowId::new(pid, 1), rect(0, 0, 50, 100)),
                 (WindowId::new(pid, 2), rect(50, 0, 50, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    use crate::model::RootOrientation;
+
+    fn config_with_root_orientation(orientation: RootOrientation) -> Arc<Config> {
+        let mut config = Config::default();
+        config.settings.default_root_orientation = orientation;
+        Arc::new(config)
+    }
+
+    #[test]
+    fn auto_root_orientation_stacks_windows_on_a_portrait_screen() {
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        mgr.set_config(&config_with_root_orientation(RootOrientation::Auto));
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 100, 300);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 100, 150)),
+                (WindowId::new(pid, 2), rect(0, 150, 100, 150)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn auto_root_orientation_leaves_a_landscape_screen_side_by_side() {
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        mgr.set_config(&config_with_root_orientation(RootOrientation::Auto));
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        let screen = rect(0, 0, 300, 100);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 150, 100)),
+                (WindowId::new(pid, 2), rect(150, 0, 150, 100)),
+            ],
+            mgr.layout_sorted(space, screen),
+        );
+    }
+
+    #[test]
+    fn default_root_orientation_ignores_the_screen_shape() {
+        use LayoutEvent::*;
+        let mut mgr = LayoutManager::new_for_test();
+        let space = SpaceId::new(1);
+        let pid = 1;
+        let windows = make_windows(pid, 2);
+
+        // The default is horizontal, so a portrait screen still splits
+        // across rather than stacking.
+        let screen = rect(0, 0, 100, 300);
+        _ = mgr.handle_event(SpaceExposed(space, screen.size));
+        _ = mgr.handle_event(WindowsOnScreenUpdated(space, pid, windows));
+
+        assert_eq!(
+            vec![
+                (WindowId::new(pid, 1), rect(0, 0, 50, 300)),
+                (WindowId::new(pid, 2), rect(50, 0, 50, 300)),
             ],
             mgr.layout_sorted(space, screen),
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::actor::wm_controller::WmCommand;
-use crate::model::LayoutKind;
+use crate::model::{LayoutKind, RootOrientation};
 
 pub fn data_dir() -> PathBuf {
     dirs::home_dir().unwrap().join(".glide")
@@ -98,6 +98,7 @@ pub struct Settings {
     pub inner_gap: f64,
     pub default_keys: bool,
     pub default_layout_kind: LayoutKind,
+    pub default_root_orientation: RootOrientation,
     #[derive_args(GroupBarsPartial)]
     pub group_bars: GroupBars,
     #[derive_args(StatusIconPartial)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -16,5 +16,5 @@ mod window;
 
 pub use layout_mapping::SpaceLayoutMapping;
 pub use layout_tree::{LayoutId, LayoutKind, LayoutTree};
-pub use size::{ContainerKind, Direction, GroupBarInfo, Orientation};
+pub use size::{ContainerKind, Direction, GroupBarInfo, Orientation, RootOrientation};
 pub use tree::NodeId;

--- a/src/model/layout_mapping.rs
+++ b/src/model/layout_mapping.rs
@@ -31,9 +31,14 @@ enum SaveState {
 }
 
 impl SpaceLayoutMapping {
-    pub fn new(size: CGSize, tree: &mut LayoutTree, kind: LayoutKind) -> Self {
+    pub fn new(
+        size: CGSize,
+        tree: &mut LayoutTree,
+        kind: LayoutKind,
+        orientation: Orientation,
+    ) -> Self {
         let layout = match kind {
-            LayoutKind::Tree => tree.create_layout(),
+            LayoutKind::Tree => tree.create_layout_with_orientation(orientation),
             LayoutKind::Scroll => tree.create_scroll_layout(),
         };
         SpaceLayoutMapping {
@@ -180,7 +185,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::collections::HashMap;
-use crate::model::{LayoutId, LayoutKind, LayoutTree};
+use crate::model::{LayoutId, LayoutKind, LayoutTree, Orientation};
 
 #[cfg(test)]
 mod tests {
@@ -193,7 +198,8 @@ mod tests {
     #[test]
     fn unmodified_layout_is_reused() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
         let layout1 = mapping.active_layout();
         assert_eq!(tree.layouts().len(), 1);
 
@@ -213,7 +219,8 @@ mod tests {
     #[test]
     fn prepare_modify_reuses_unique_layouts() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
         let original_layout = mapping.active_layout();
 
         let modified_layout = mapping.prepare_modify(&mut tree);
@@ -224,7 +231,8 @@ mod tests {
     #[test]
     fn prepare_modify_clones_shared_layouts() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
         let original_layout = mapping.active_layout();
         assert_eq!(tree.layouts().len(), 1);
 
@@ -243,7 +251,8 @@ mod tests {
     #[test]
     fn state_is_not_saved_without_retention() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
 
         // Switch without retention - should not save to memory
         mapping.activate_size(SIZE_2, &mut tree);
@@ -266,7 +275,8 @@ mod tests {
     #[test]
     fn state_is_saved_with_retention() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
 
         // Switch with retention - should save to memory
         mapping.retain_layout();
@@ -288,7 +298,8 @@ mod tests {
     #[test]
     fn correct_refcount_with_retain() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
         let layout1 = mapping.active_layout();
 
         // Initially refcount should be 1
@@ -320,7 +331,8 @@ mod tests {
     #[test]
     fn garbage_collection_removes_layouts_when_unused() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
         let layout1 = mapping.active_layout();
         assert_eq!(mapping.layouts().len(), 1);
         assert_eq!(tree.layouts().len(), 1);
@@ -350,7 +362,8 @@ mod tests {
     #[test]
     fn change_index() {
         let mut tree = LayoutTree::new();
-        let mut mapping = SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree);
+        let mut mapping =
+            SpaceLayoutMapping::new(SIZE_1, &mut tree, LayoutKind::Tree, Orientation::Horizontal);
 
         // Make three layouts.
         let layout1 = mapping.active_layout();

--- a/src/model/layout_tree.rs
+++ b/src/model/layout_tree.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::selection::Selection;
-use super::size::{ContainerKind, Direction, Size};
+use super::size::{ContainerKind, Direction, Orientation, Size};
 use super::tree::{self, Tree};
 use super::window::Window;
 use crate::actor::app::{WindowId, pid_t};
@@ -49,23 +49,25 @@ impl LayoutTree {
     }
 
     pub fn create_layout(&mut self) -> LayoutId {
-        self.create_layout_with_kind(LayoutKind::Tree)
+        self.create_layout_with_orientation(Orientation::Horizontal)
+    }
+
+    /// Creates a tree layout whose root splits along `orientation`.
+    pub fn create_layout_with_orientation(&mut self, orientation: Orientation) -> LayoutId {
+        self.create_layout_with_kind(LayoutKind::Tree, ContainerKind::from(orientation))
     }
 
     pub fn create_scroll_layout(&mut self) -> LayoutId {
-        self.create_layout_with_kind(LayoutKind::Scroll)
+        // A scroll layout is a row of columns, so its root is always
+        // horizontal regardless of the screen's shape.
+        self.create_layout_with_kind(LayoutKind::Scroll, ContainerKind::Horizontal)
     }
 
-    fn create_layout_with_kind(&mut self, kind: LayoutKind) -> LayoutId {
+    fn create_layout_with_kind(&mut self, kind: LayoutKind, root_kind: ContainerKind) -> LayoutId {
         let root = OwnedNode::new_root_in(&mut self.tree, "layout_root");
         let id = self.layout_roots.insert(root);
         self.layout_kinds.insert(id, kind);
-        if kind == LayoutKind::Scroll {
-            self.tree
-                .data
-                .size
-                .set_kind(self.layout_roots[id].id(), ContainerKind::Horizontal);
-        }
+        self.tree.data.size.set_kind(self.layout_roots[id].id(), root_kind);
         id
     }
 

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -53,6 +53,31 @@ pub enum Orientation {
     Vertical,
 }
 
+/// The orientation a new layout's root container starts out with.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootOrientation {
+    #[default]
+    Horizontal,
+    Vertical,
+    /// Split the screen's longer axis, so a portrait screen stacks windows
+    /// and a landscape one puts them side by side.
+    Auto,
+}
+
+impl RootOrientation {
+    pub fn resolve(self, screen: CGSize) -> Orientation {
+        match self {
+            RootOrientation::Horizontal => Orientation::Horizontal,
+            RootOrientation::Vertical => Orientation::Vertical,
+            // A square screen has no longer axis; treat it as landscape,
+            // which is what every other orientation defaults to.
+            RootOrientation::Auto if screen.height > screen.width => Orientation::Vertical,
+            RootOrientation::Auto => Orientation::Horizontal,
+        }
+    }
+}
+
 impl ContainerKind {
     pub fn orientation(self) -> Orientation {
         use ContainerKind::*;
@@ -987,6 +1012,28 @@ mod tests {
             window1_fullscreen_frame,
             rect(10, 10, 980, 980),
             "window1 fullscreen with outer_gap"
+        );
+    }
+
+    #[test]
+    fn root_orientation_auto_splits_the_longer_axis() {
+        let portrait = CGSize { width: 100.0, height: 300.0 };
+        let landscape = CGSize { width: 300.0, height: 100.0 };
+        let square = CGSize { width: 100.0, height: 100.0 };
+
+        assert_eq!(Orientation::Vertical, RootOrientation::Auto.resolve(portrait));
+        assert_eq!(Orientation::Horizontal, RootOrientation::Auto.resolve(landscape));
+        // A square screen has no longer axis; it falls back to landscape.
+        assert_eq!(Orientation::Horizontal, RootOrientation::Auto.resolve(square));
+
+        // The explicit settings ignore the screen entirely.
+        assert_eq!(
+            Orientation::Horizontal,
+            RootOrientation::Horizontal.resolve(portrait)
+        );
+        assert_eq!(
+            Orientation::Vertical,
+            RootOrientation::Vertical.resolve(landscape)
         );
     }
 }


### PR DESCRIPTION
Implements #241.

## The problem

New layouts always get a horizontal root, so windows tile side by side regardless of the screen's shape. `create_layout_with_kind` only set a root kind for scroll layouts; tree layouts took `ContainerKind::default()`, which is `Horizontal`.

On a portrait screen that splits the narrow axis. Two windows on 1296x2304 come out 648 wide and 2304 tall. Stacked they would be 1296x1152.

## What this adds

```toml
# "horizontal" | "vertical" | "auto"
default_root_orientation = "auto"
```

`auto` splits the screen's longer axis: vertical when taller than wide, horizontal otherwise. Defaults to `horizontal`, so nothing changes unless it is set.

## Design notes

**Aspect ratio rather than naming displays.** This avoids introducing a way to identify displays in config, which would be a much larger design question. It is also what AeroSpace does with `default-root-container-orientation = 'auto'`. An explicit per-display override could layer on later if anyone asks for one.

**A square screen falls back to horizontal**, since it has no longer axis and horizontal is what every other path defaults to. Covered by a test.

**Applies at creation only.** `activate_size` reuses the existing layout when a space appears at a new size, so a layout carried from landscape to portrait keeps its orientation. Silently rearranging a layout the user has set up seemed worse than leaving it, but say the word if you would rather it re-resolved on every size change.

**Scroll layouts are unaffected.** Their root is a row of columns, so it stays horizontal whatever the screen's shape. `create_scroll_layout` now says so directly rather than relying on the shared branch.

**No new plumbing.** `SpaceExposed(SpaceId, CGSize)` already carries the screen size and is handled immediately before the layout is created, so the orientation is resolved at the point of decision.

## Tests

Four, verified to fail before the change and pass after:

- `auto_root_orientation_stacks_windows_on_a_portrait_screen`
- `auto_root_orientation_leaves_a_landscape_screen_side_by_side`
- `default_root_orientation_ignores_the_screen_shape` — the default still splits horizontally on a portrait screen
- `root_orientation_auto_splits_the_longer_axis` — unit test for `resolve`, including the square case

Removing the `auto` branch fails only the portrait test, leaving the other two layout tests passing, so each covers a distinct behaviour.

The existing suite passes unchanged, which is the check that matters for the default staying `horizontal`.